### PR TITLE
Form request for new reservation, fixed UI

### DIFF
--- a/app/Http/Controllers/GazeboController.php
+++ b/app/Http/Controllers/GazeboController.php
@@ -134,7 +134,6 @@ class GazeboController extends Controller {
     }
 
     protected function getCurrenDayReservations(Request $request) {
-        $request->session()->keep(['errors']);
         $type = $request->only('type')['type'];
         return Redirect::back()->with(['current_day_reservations' => Reservation::date(date('y-m-d'))->type($type)->with(['Rooms'])->status('Cancelled', true)->get()]);
     }

--- a/app/Http/Requests/NewReservationRequest.php
+++ b/app/Http/Requests/NewReservationRequest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\DisabledDay;
+use App\Models\DisabledTable;
+use App\Models\Reservation;
+use Illuminate\Foundation\Http\FormRequest;
+
+class NewReservationRequest extends FormRequest {
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        $rules = [
+            'date' => 'required|date',
+            'table' => 'required|uuid',
+            'type' => 'required|string|in:Dinner,Bed',
+            'number_of_people' => 'required|numeric|min:1',
+            'attendees' => 'required_if:number_of_people,>1|array_length:' . ($this->input('number_of_people') - 1),
+            'first_name' => 'required|string',
+            'last_name' => 'required|string',
+            'email' => 'required|email',
+            'phone_number' => 'required|numeric',
+            'primary_room' => 'required|numeric|min_digits:3|max_digits:4',
+            'secondary_room' => 'nullable|numeric|min_digits:3|max_digits:4',
+            'notes' => 'nullable|string|max:250',
+            'more_rooms' => 'required|boolean',
+            'primary_menu' => 'required|array',
+            'primary_menu.Main' => 'required_if:type,Dinner|uuid',
+            'primary_menu.Dessert' => 'nullable|required_if:type,Dinner|uuid',
+            'secondary_menu' => 'required|array',
+            'secondary_menu.Main' => [
+                'sometimes',
+                'nullable',
+                function ($attribute, $value, $fail) {
+                    if ($this->input('type') === 'Dinner' && $this->input('more_rooms') === true) {
+                        if (empty($value)) {
+                            $fail("The $attribute field is required when type is Dinner and there is more than 1 rooms.");
+                        }
+                    }
+                },
+                'uuid'
+            ],
+            'secondary_menu.Dessert' => [
+                'sometimes',
+                'nullable',
+                function ($attribute, $value, $fail) {
+                    if ($this->input('type') === 'Dinner' && $this->input('more_rooms')=== true) {
+                        if (empty($value)) {
+                            $fail("The $attribute field is required when type is Dinner and there is more than 1 rooms.");
+                        }
+                    }
+                },
+                'uuid',
+            ],
+        ];
+
+        if ($this->input('type') === 'Dinner') {
+            $rules['number_of_people'] .= '|max:4';
+        } elseif ($this->input('type') === 'Bed') {
+            $rules['number_of_people'] .= '|max:2';
+        }
+
+        return $rules;
+    }
+
+    public function messages() {
+        return [
+            'date.required' => 'The date field is required.',
+            'table.required' => 'The Gazebo field is required.',
+            'type.required' => 'The type field is required.',
+            'number_of_people.required' => 'The number of people field is required.',
+            'number_of_people.numeric' => 'The number of people field must be a number.',
+            'number_of_people.min' => 'The number of people must be at least 1.',
+            'number_of_people.max' => 'The number of people field cannot exceed :max when type is :type.',
+            'first_name.required' => 'The first name field is required.',
+            'last_name.required' => 'The last name field is required.',
+            'email.required' => 'The email field is required.',
+            'email.email' => 'Please enter a valid email address.',
+            'phone_number.required' => 'The phone number field is required.',
+            'phone_number.numeric' => 'The phone number field must be a number.',
+            'primary_room.required' => 'The primary room field is required.',
+            'secondary_room.numeric' => 'The secondary room field must be a number.',
+            'notes.max' => 'The notes field cannot exceed :max characters.',
+            'more_rooms.required' => 'The more rooms field is required.',
+            'primary_menu.Main.required_if' => 'The primary menu main dish selection is required.',
+            'primary_menu.Dessert.required_if' => 'The primary menu dessert dish selection is required.',
+            'secondary_menu.Main.required_if' => 'Main Dish for :secondary_room cannot be empty',
+            'secondary_menu.Dessert.required_if' => 'Dessert for :secondary_room cannot be empty',
+            'attendees.array_length' => 'The number of attendees must be equal to the number of guests minus 1.',
+        ];
+    }
+
+    public function withValidator($validator) {
+        $validator->after(function ($validator) {
+            $validatedData = $this->validated();
+            $Reservation_Exists = Reservation::date($validatedData['date'])->table($validatedData['table'])->type($validatedData['type'])->exists();
+            $Date_Disabled_Reservations_Not_Allowed = DisabledDay::date($validatedData['date'])->allowReservations(false)->type($validatedData['type'])->exists();
+            $Gazebo_Is_Disabled = DisabledTable::date($validatedData['date'])->type($validatedData['type'])->exists();
+            if($Date_Disabled_Reservations_Not_Allowed) {
+                $validator->errors()->add('day_disabled',
+                    'It seems that the selected date is not available for booking anymore. Please select another date.');
+            }
+            if($Reservation_Exists || $Gazebo_Is_Disabled) {
+                $validator->errors()->add('gazebo_occupied',
+                    'It seems that the gazebo you are trying to book is not available on the selected date. Please select another gazebo or another date.');
+            }
+        });
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
 use Inertia\Inertia;
 
@@ -22,5 +23,14 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void {
         JsonResource::withoutWrapping();
+        Validator::extend('array_length', function ($attribute, $value, $parameters, $validator) {
+            $expectedLength = (int) $parameters[0];
+
+            if (is_array($value) && count($value) === $expectedLength) {
+                return true;
+            }
+
+            return false;
+        });
     }
 }

--- a/resources/css/Admin.css
+++ b/resources/css/Admin.css
@@ -281,6 +281,9 @@ abbr[title] {
 .mw-200px {
     max-width: 200px;
 }
+.mw-220px {
+    max-width: 220px;
+}
 .mw-250px {
     max-width: 250px;
 }

--- a/resources/js/Alerts/AlertMessage.jsx
+++ b/resources/js/Alerts/AlertMessage.jsx
@@ -2,7 +2,7 @@ import {useEffect, useState} from "react";
 import {Alert} from "react-bootstrap";
 
 
-export function AlertMessage({duration=5, variant = 'primary',header ='', message = '',
+export function AlertMessage({duration=5, variant = 'primary',header ='', errors = {},
                              onClose = ()=>{}, className=''}) {
     const [show, setShow] = useState(true);
 
@@ -11,21 +11,24 @@ export function AlertMessage({duration=5, variant = 'primary',header ='', messag
         onClose();
     }
 
-    useEffect(()=>{
-        if(show)
-            setTimeout(()=>{
-                handleClose();
-                console.log('Done')
-            },duration*1000);
-    },[show]);
+    // useEffect(()=>{
+    //     if(show)
+    //         setTimeout(()=>{
+    //             handleClose();
+    //             console.log('Done')
+    //         },duration*1000);
+    // },[show]);
 
-
+    // console.log('errors',errors)
     return (
-        <Alert variant={variant} show={show} onClose={handleClose} dismissible className={className}>
-            <Alert.Heading>{header}</Alert.Heading>
-            <p>
-                {message}
-            </p>
-        </Alert>
+        Object.keys(errors).map((error, index)=>{
+            console.log('error',error)
+            return <Alert key={index} variant={variant} show={show} onClose={handleClose} dismissible className={className}>
+                <Alert.Heading>{header}</Alert.Heading>
+                <p>
+                    {errors[error]}
+                </p>
+            </Alert>
+        })
     );
 }

--- a/resources/js/CustomHooks/useCheckChanges.jsx
+++ b/resources/js/CustomHooks/useCheckChanges.jsx
@@ -51,7 +51,7 @@ export default function useCheckChanges(previous, next, Gazebos) {
    useTimeout(()=>{
        if(hasChanges)
            setHasChanges(false);
-   }, alert.variant === 'success' ? 3000 : 4500);
+   }, alert.variant === 'success' ? 3500 : 5500);
 
  return <Alert show={hasChanges} onClose={()=>setHasChanges(false)} variant={alert.variant} dismissible className={'px-2 py-3 text-center'}>
      <CheckSVG width={24} height={24} className={'mb-2'}/>

--- a/resources/js/Inertia_Requests/Admin_Requests.js
+++ b/resources/js/Inertia_Requests/Admin_Requests.js
@@ -10,7 +10,6 @@ export const getParameter = (activeRange) => {
 
 export const handleSetReservations = (res, activeRange, setReservations, activeView) => {
     if(activeView === 'Search') {
-        console.log('GotIn')
         return setReservations(res.props.activeReservation);
     }
     if(!activeRange)
@@ -44,7 +43,7 @@ export const handleChangeReservationStatus = (status, activeReservation, setActi
     Inertia.patch(route('Change_Reservation_Status'),{date_start:getDate(0, activeRange), date_end:getDate(1, activeRange)
         ,reservation_id:activeReservation.id,status:status},{
         onSuccess:(res)=> {
-            console.log('res', res.props.activeReservation)
+            // console.log('res', res.props.activeReservation)
             setActiveReservation(res.props.activeReservation);
             // handleSetReservation(res.props.activeReservation);
             handleSetReservations(res,activeRange, setReservations, activeView);

--- a/resources/js/Pages/Admin/AdminPanel.jsx
+++ b/resources/js/Pages/Admin/AdminPanel.jsx
@@ -141,7 +141,7 @@ export default function AdminPanel(props) {
                                                                             <Card.Header className={'text-center border-0 bg-transparent mt-xs-2 mt-lg-1 '}>
                                                                                 {typeAndViewSelectionPanel}
                                                                             </Card.Header>}
-                                                                        <Card.Body className={'px-0 px-lg-2 px-xl-2 rounded-4 border-0 mt-0 mt-lg-3 overflow-x-hidden py-0'}>
+                                                                        <Card.Body className={'px-0 px-lg-2 px-xl-2 rounded-4 border-0 mt-0 mt-lg-3 overflow-x-hidden py-0 d-flex flex-column'}>
                                                                             <PendingUnsavedChangesContext.Provider value={{pendingUnsavedChanges,setPendingUnsavedChanges}}>
                                                                                 <ShouldShowUnsavedChangesModalContext.Provider value={{showUnsavedChangesWarningModal,setShowUnsavedChangesWarningModal,handleSetActiveKey}}>
                                                                                     <FetchReservationsContext.Provider value={{shouldFetchReservations, setShouldFetchReservations}}>

--- a/resources/js/Pages/Admin/EditReservations/ReservationEditingOptions.jsx
+++ b/resources/js/Pages/Admin/EditReservations/ReservationEditingOptions.jsx
@@ -60,12 +60,14 @@ export function ReservationEditingOptions({conflictType = '', edit, children = n
                 {canChangeGazeboSameDay &&
                     <Col className={'d-flex flex-column'} xs={6}>
                         <p className={'info-text-lg mb-3'}>Gazebo</p>
-                        {noAvailableTablesExist &&
-                            <p className={'text-danger fw-bold info-text-lg mt-2 mb-1'}>Δεν υπάρχουν διαθέσιμα Gazebo την ίδια μέρα.</p>}
-                        <Button variant={'secondary'} className={'m-auto ' + (noAvailableTablesExist ? 'opacity-25' : '')}
-                                onClick={handleClickChangeTable} disabled={noAvailableTablesExist || isDateDisabled}>
-                            Αλλαγή Gazebo
-                        </Button>
+                        {noAvailableTablesExist ?
+                            <p className={'info-text-lg mt-2 mb-1 px-3 fst-italic'}>Δεν υπάρχουν διαθέσιμα Gazebo την ίδια μέρα.</p>
+                        :
+                            <Button variant={'secondary'} className={'m-auto ' + (noAvailableTablesExist ? 'opacity-25' : '')}
+                                    onClick={handleClickChangeTable} disabled={noAvailableTablesExist || isDateDisabled}>
+                                Αλλαγή Gazebo
+                            </Button>
+                        }
                     </Col>}
                 <Col xs={canChangeGazeboSameDay ? 6 : 12} className={'d-flex flex-column my-3 my-sm-0'}>
                     <p className={'info-text-lg mb-3 '}>Μενού</p>

--- a/resources/js/Pages/Admin/EditReservations/SameDay/ChangeReservationTableSameDay.jsx
+++ b/resources/js/Pages/Admin/EditReservations/SameDay/ChangeReservationTableSameDay.jsx
@@ -22,7 +22,7 @@ export function ChangeReservationTableSameDay({edit, availability}) {
     {editing, setEditing} = edit;
     const [isReservationInConflict,conflictType,conflictMessage] = useCheckConflict(activeReservation.id),
     [activeRange, setReservations] = useContext(ActiveRangeContext);
-    console.log(activeReservation)
+
     const handleSelectTable = (table,index) => {
         if(table.isAvailable && table.id !== activeReservation.gazebo_id)
             setSelectedTable(table.id);

--- a/resources/js/Pages/Admin/OffCanvases/MobileUtilityOffCanvas.jsx
+++ b/resources/js/Pages/Admin/OffCanvases/MobileUtilityOffCanvas.jsx
@@ -19,7 +19,7 @@ export function MobileUtilityOffCanvas({height = 20,children, title = ''}) {
                 <Offcanvas.Header className={'justify-content-center pb-0 pt-1'} onClick={()=>setShow(false)}>
                     <ChevronDownSVG/>
                 </Offcanvas.Header>
-                <Offcanvas.Body className={'d-flex px-2 pt-3 pt-md-1 overflow-y-auto scroll-bar-hidden'}>
+                <Offcanvas.Body className={'d-flex px-2 pt-0 pt-md-1 overflow-y-auto scroll-bar-hidden'}>
                     {children}
                 </Offcanvas.Body>
             </Offcanvas>

--- a/resources/js/Pages/Admin/Reservations/CancelledView/CancelledView.jsx
+++ b/resources/js/Pages/Admin/Reservations/CancelledView/CancelledView.jsx
@@ -12,7 +12,7 @@ export function CancelledView() {
         <ActiveRangeContext.Provider value={[null, ()=>{}]}>
             {innerWidth > 992 ?
                 <LargeDevicesCancelledView reservationType={reservationType} requestProgress={requestProgress} cancelledReservations={reservations}>
-                    <h5>Εμφανίζονται μόνο οι ακυρωμένες κρατήσεις</h5>
+                    <h5>Εμφανίζονται μόνο οι ακυρωμένες {reservationType === 'Dinner' ? 'βραδινές' : 'πρωινές'} κρατήσεις</h5>
                 </LargeDevicesCancelledView>
                 :
                 <MobileCancelledView cancelledReservations={reservations} requestProgress={requestProgress} reservationType={reservationType}>

--- a/resources/js/Pages/Admin/Reservations/CancelledView/LargeDevicesCancelledView.jsx
+++ b/resources/js/Pages/Admin/Reservations/CancelledView/LargeDevicesCancelledView.jsx
@@ -18,7 +18,7 @@ export function LargeDevicesCancelledView({requestProgress, cancelledReservation
 
     const reservationsToShow = useCallback(()=> {
         if(!reservationsExist)
-            return <h4 className={'text-muted my-auto user-select-none info-text-xl'}>Δεν υπάρχει κάποια ακυρωμένη κράτηση</h4>;
+            return <h4 className={'text-muted my-auto user-select-none info-text-xl'}>Δεν υπάρχει κάποια ακυρωμένη {reservationType === 'Dinner' ? 'βραδινή' : 'πρωινή'} κράτηση</h4>;
 
         const reservationsToRender = innerWidth < 1500 ? (activeReservation === null ? 2 : 1) : (innerWidth > 1700 ? (activeReservation === null ? 4 : 2)  : (activeReservation === null ? 3 : 2));
         // Will always try to show 2 reservations per line, to save space.

--- a/resources/js/Pages/Admin/Reservations/FiltersBar/FiltersBar.jsx
+++ b/resources/js/Pages/Admin/Reservations/FiltersBar/FiltersBar.jsx
@@ -6,19 +6,19 @@ export function FiltersBar({reservationsFilter,setReservationsFilter,direction='
             setReservationsFilter(filter);
     }
     return (
-            <Stack direction={direction} className={'d-flex flex-wrap filters-bar-stack  border-secondary-subtle border rounded-4 p-2 ' + className} gap={innerWidth < 500 ? 2 : 3}>
+            <Stack direction={direction} className={'d-flex flex-wrap filters-bar-stack  border-secondary-subtle border rounded-4 p-2 mw-300px ' + className} gap={innerWidth < 500 ? 2 : 3}>
                 <Badge pill bg={"dark"}
-                       className={'cursor-pointer user-select-none hover-scale-0_95 '
+                       className={'cursor-pointer user-select-none hover-scale-0_95 flex-fill '
                            + ((reservationsFilter === 'All' || disabled)? ' opacity-25' : '')}
                        onClick={()=>handleClick('All')} >
                     Όλες
                 </Badge>
-                <Badge pill bg={"warning"} className={'cursor-pointer user-select-none hover-scale-0_95 '
+                <Badge pill bg={"warning"} className={'cursor-pointer user-select-none hover-scale-0_95 flex-fill  '
                     + ((reservationsFilter === 'Pending' || disabled)? ' opacity-25' : '')}
                        onClick={()=>handleClick('Pending')}>
                     Εκκρεμείς
                 </Badge>
-                <Badge pill bg={"success"} className={'cursor-pointer user-select-none hover-scale-0_95 '
+                <Badge pill bg={"success"} className={'cursor-pointer user-select-none hover-scale-0_95 flex-fill  '
                     + ((reservationsFilter === 'Confirmed' || disabled)? ' opacity-25' : '')}
                        onClick={()=>handleClick('Confirmed')}>
                     Επιβεβαιωμένες

--- a/resources/js/Pages/Admin/Reservations/MonthlyView/LargeDevicesMonthlyView.jsx
+++ b/resources/js/Pages/Admin/Reservations/MonthlyView/LargeDevicesMonthlyView.jsx
@@ -1,13 +1,16 @@
 import {Col, Row, Stack} from "react-bootstrap";
+import {ActiveReservationTypeContext} from "../../Contexts/ActiveReservationTypeContext";
+import {ActiveReservationContext} from "../../Contexts/ActiveReservationContext";
 import {FiltersBar} from "../FiltersBar/FiltersBar";
 import {useContext} from "react";
-import {ActiveReservationContext} from "../../Contexts/ActiveReservationContext";
 import {ReservationLong} from "../ReservationViews/ReservationLong/ReservationLong";
+import {formatDateInGreek} from "../../../../ExternalJs/Util";
 
 export function LargeDevicesMonthlyView({Calendar,reservationsToShow,
     reservationsFilter,setReservationsFilter, selectedDate}) {
     const [reservations, reservationsCount] = reservationsToShow(),
-    {activeReservation, setActiveReservation} = useContext(ActiveReservationContext);
+    {activeReservation, setActiveReservation} = useContext(ActiveReservationContext),
+    {reservationType,setReservationType} = useContext(ActiveReservationTypeContext);
 
     return (
         <Row className={'text-center h-100 d-flex'}>
@@ -19,6 +22,8 @@ export function LargeDevicesMonthlyView({Calendar,reservationsToShow,
                              disabled={selectedDate === ''}
                              setReservationsFilter={setReservationsFilter}
                              className={'mx-auto my-3'}/>}
+                {selectedDate && <h5>{formatDateInGreek(selectedDate)}</h5>}
+                <h6>{reservationType === 'Dinner' ? 'Βραδινές Κρατήσεις' : 'Πρωινές Κρατήσεις'}</h6>
                 <Stack className={'px-0 overflow-y-auto my-auto'} >
                     {reservations}
                 </Stack>

--- a/resources/js/Pages/Admin/Reservations/MonthlyView/MobileMonthlyView.jsx
+++ b/resources/js/Pages/Admin/Reservations/MonthlyView/MobileMonthlyView.jsx
@@ -1,17 +1,18 @@
-import {Col, Row, Stack} from "react-bootstrap";
-import {useState} from "react";
-import {useEffect} from "react";
-import {useContext} from "react";
 import {ActiveReservationContext} from "../../Contexts/ActiveReservationContext";
+import {ActiveReservationTypeContext} from "../../Contexts/ActiveReservationTypeContext";
+import {Col, Row, Stack} from "react-bootstrap";
+import {useState, useContext, useEffect} from "react";
 import {LeftArrowSVG} from "../../../../SVGS/LeftArrowSVG";
 import {FiltersBar} from "../FiltersBar/FiltersBar";
 import {MobileActiveReservationOffCanvas} from "../../OffCanvases/MobileActiveReservationOffCanvas";
+import {formatDateInGreek} from "../../../../ExternalJs/Util";
 
 export function MobileMonthlyView({Calendar, reservationsToShow, selectedDate,
     reservationsFilter,setReservationsFilter}) {
     const [shouldShowCalendar,setShouldShowCalendar] = useState(true),
     {activeReservation,setActiveReservation} = useContext(ActiveReservationContext),
-    [reservations, reservationsCount] = reservationsToShow();
+    [reservations, reservationsCount] = reservationsToShow(),
+    {reservationType,setReservationType} = useContext(ActiveReservationTypeContext);
 
     useEffect(()=>{
         if(selectedDate !== '')
@@ -35,6 +36,8 @@ export function MobileMonthlyView({Calendar, reservationsToShow, selectedDate,
                                 reservationsFilter={reservationsFilter}
                                 className={'mx-auto border-secondary-subtle border rounded-4 p-2 my-3'}>
                     </FiltersBar>}
+                {selectedDate && <h5>{formatDateInGreek(selectedDate)}</h5>}
+                <h6>{reservationType === 'Dinner' ? 'Βραδινές Κρατήσεις' : 'Πρωινές Κρατήσεις'}</h6>
                 <Stack className={'p-3 overflow-y-auto d-flex' + (innerWidth > 992 ? ' mh-600px' : ' h-75')}>
                     {reservations}
                 </Stack>

--- a/resources/js/Pages/Admin/Reservations/ReservationViews/ReservationLong/ReservationLong.jsx
+++ b/resources/js/Pages/Admin/Reservations/ReservationViews/ReservationLong/ReservationLong.jsx
@@ -29,7 +29,7 @@ export function ReservationLong() {
     rooms = reservation?.Rooms,
     attendees = reservation?.Attendees,
     attendeesExist = attendees?.length > 0,
-    Gazebo = getTableAA(reservation?.Gazebo,Tables),
+    Gazebo = getTableAA(activeReservation?.gazebo_id,Tables),
     menus = reservation?.Menus,
     notes = reservation?.Notes,
     type = reservation?.Type,

--- a/resources/js/Pages/Admin/Reservations/ReservationViews/ReservationShortest.jsx
+++ b/resources/js/Pages/Admin/Reservations/ReservationViews/ReservationShortest.jsx
@@ -43,7 +43,7 @@ export const ReservationShortest = forwardRef(function ReservationShortest({Rese
             <section className={'d-flex flex-column text-start p-1'}>
                 <h6 className={'mb-2 user-select-none text-center'}>Στοιχεία Κράτησης</h6>
                 <p className={'my-1 user-select-none info-text'}>Gazebo</p>
-                <p className={'my-0 user-select-none'}>Gazebo {getTableAA(Reservation?.Gazebo,Tables)}</p>
+                <p className={'my-0 user-select-none'}>Gazebo {getTableAA(Reservation?.gazebo_id,Tables)}</p>
                 <section className={'my-2 user-select-none'}>
                     <span className={'info-text'}> {Rooms.length > 1 ? 'Δωμάτια' : 'Δωμάτιο'}</span>
                     <section>

--- a/resources/js/Pages/Admin/Reservations/TodaysView/LargeDevicesTodayView.jsx
+++ b/resources/js/Pages/Admin/Reservations/TodaysView/LargeDevicesTodayView.jsx
@@ -51,6 +51,7 @@ export function LargeDevicesTodayView({reservations_of_current_date,filter,child
         <Row className={'h-100 w-100 d-flex'}>
             <Col className={'pe-0 pb-3 h-100 m-auto pt-4 d-flex flex-column text-center'} lg={reservationsExist && activeReservation !== null ? 7 : 12}>
                 {children}
+                <h6>{reservationType === 'Dinner' ? 'Βραδινές Κρατήσεις' : 'Πρωινές Κρατήσεις'}</h6>
                 {reservationsExist && <FiltersBar setReservationsFilter={setReservationsFilter}
                   reservationsFilter={reservationsFilter} direction={'horizontal'}
                   className={'mx-auto my-2'}>

--- a/resources/js/Pages/Admin/Reservations/TodaysView/MobileTodayView.jsx
+++ b/resources/js/Pages/Admin/Reservations/TodaysView/MobileTodayView.jsx
@@ -53,20 +53,25 @@ export function MobileTodayView({reservations_of_current_date, filter, children,
     return ( <div className={'h-100 d-flex flex-column text-center'}>
             {shouldShowStack ? <>
                 <MobileUtilityOffCanvas title={'Φίλτρα και Πληροφορίες'} height={20}>
-                    <Stack direction={(innerWidth > innerHeight ) ? 'horizontal' : 'vertical'} gap={3} className={'flex-fill'}>
+                    <Stack direction={(innerWidth > innerHeight ) ? 'horizontal' : 'vertical'} gap={2} className={'d-flex w-100'}>
+                        <section className={'d-flex flex-column text-center flex-fill'}>
                             {children}
-                        <section className={'d-flex gap-4'}>
+                            <h6 className={'mt-1'}>{reservationType === 'Dinner' ? 'Βραδινές Κρατήσεις' : 'Πρωινές Κρατήσεις'}</h6>
+                        </section>
+                        <section className={'flex-fill d-flex'}>
                             {
-                                isDateDisabled ? <Badge bg="danger" className={'m-auto ms-'}>Απενεργοποιημένη</Badge> :
-                                    <AdminToNewReservationFormModal returnButton reservationType={reservationType}/>
+                                isDateDisabled ? <Badge bg="danger" className={'m-auto'}>Απενεργοποιημένη</Badge> :
+                                        <AdminToNewReservationFormModal returnButton reservationType={reservationType}/>
                             }
                         </section>
-                        {reservations_of_current_date.length > 0 &&
-                            <FiltersBar setReservationsFilter={setReservationsFilter}
-                                        disabled={reservations_of_current_date.length === 0}
-                                        reservationsFilter={reservationsFilter}
-                                        direction={'horizontal'}
-                                        className={'m-auto'}></FiltersBar>}
+                        <section className={'flex-fill'}>
+                            {reservations_of_current_date.length > 0 &&
+                                <FiltersBar setReservationsFilter={setReservationsFilter}
+                                            disabled={reservations_of_current_date.length === 0}
+                                            reservationsFilter={reservationsFilter}
+                                            direction={'horizontal'}
+                                            className={'m-auto'}></FiltersBar>}
+                        </section>
                     </Stack>
                 </MobileUtilityOffCanvas>
                 <Stack className={'mt-1 px-4 mx-auto text-center overflow-y-auto h-85'}>

--- a/resources/js/Pages/Admin/Reservations/WeeklyView/LargeDevicesWeeklyView.jsx
+++ b/resources/js/Pages/Admin/Reservations/WeeklyView/LargeDevicesWeeklyView.jsx
@@ -83,7 +83,7 @@ export function LargeDevicesWeeklyView({currentDate, direction, filter, navigate
             <Col className={'text-center p-2 h-100 position-relative d-flex flex-column'}>
                 <div className="navigation my-1 d-flex flex-row">
                     <Button onClick={handlePrevWeek} variant={"secondary"} size={'sm'} className={'m-2 rounded-3 ' + (!isToday ? 'hover-scale-1_03' : '')} disabled={isToday}>Προηγούμενη Εβδομάδα</Button>
-                    <h6 className={'m-auto user-select-none'}>Κρατήσεις Εβδομάδας : {totalWeekReservations}</h6>
+                    <h6 className={'m-auto user-select-none'}>{reservationType === 'Dinner' ? 'Βραδινές' : 'Πρωινές'} Κρατήσεις Εβδομάδας : {totalWeekReservations}</h6>
                     <Button onClick={handleNextWeek} variant={"secondary"} size={'sm'} className={'m-2 rounded-3 ' + (!isLastWeek ? 'hover-scale-1_03' : '')} disabled={isLastWeek}>Επόμενη Εβδομάδα</Button>
                 </div>
                 <h6 className={'mb-4 mb-lg-0 user-select-none info-text'}>* Με <span className={'disabled-day'}>γραμμή</span> εμφανίζονται οι ημερομηνίες που έχετε απενεργοποιήσει</h6>

--- a/resources/js/Pages/Admin/Reservations/WeeklyView/MobileWeeklyView.jsx
+++ b/resources/js/Pages/Admin/Reservations/WeeklyView/MobileWeeklyView.jsx
@@ -11,11 +11,13 @@ import {ActiveReservationContext} from "../../Contexts/ActiveReservationContext"
 import {MobileActiveReservationOffCanvas} from "../../OffCanvases/MobileActiveReservationOffCanvas";
 import {DisabledDaysContext} from "../../Contexts/DisabledDaysContext";
 import {ReservationShort} from "../ReservationViews/ReservationShort";
+import {ActiveReservationTypeContext} from "../../Contexts/ActiveReservationTypeContext";
 
 export function MobileWeeklyView({currentDate, filter, children, Reservations}) {
     const {reservationsFilter, setReservationsFilter} = filter,
         [propsReservations, setPropsReservations] = Reservations,
         {activeReservation, setActiveReservation} = useContext(ActiveReservationContext),
+        {reservationType,setReservationType} = useContext(ActiveReservationTypeContext),
         disabled_days = useContext(DisabledDaysContext),
         reservationsToShow = (day)=>{
             const reservations_of_current_date = extractReservationsForDate(day,propsReservations);
@@ -76,6 +78,7 @@ export function MobileWeeklyView({currentDate, filter, children, Reservations}) 
                 <div className="navigation my-2 d-flex mx-auto">
                     {children}
                 </div>
+                <h6>{reservationType === 'Dinner' ? 'Βραδινές Κρατήσεις' : 'Πρωινές Κρατήσεις'}</h6>
                 <FiltersBar setReservationsFilter={setReservationsFilter} direction={'horizontal'}
                             reservationsFilter={reservationsFilter} className={'mx-auto my-3'}>
                 </FiltersBar>

--- a/resources/js/Pages/Forms/FinalizeReservation/FinalizeReservation.jsx
+++ b/resources/js/Pages/Forms/FinalizeReservation/FinalizeReservation.jsx
@@ -17,7 +17,7 @@ export const FinalizeReservation = forwardRef(function FinalizeReservation({...p
         Inertia.post(route('Create_Reservation'),bookingDetails,{
             preserveState:true,
             preserveScroll:true,
-            onError:(error)=>setErrors(error.Reservation),
+            onError:(error)=> setErrors(error),
         });
     };
 

--- a/resources/js/Pages/Reservations/Gazebo.jsx
+++ b/resources/js/Pages/Reservations/Gazebo.jsx
@@ -74,7 +74,7 @@ export default function Gazebo(props) {
     useEffect(()=>{
         ContainerRef.current?.scrollTo({top: ContainerRef.current?.scrollHeight,behavior:'smooth'});
     },[bookingDetails.number_of_people,bookingDetails.date]);
-
+    console.log(bookingDetails)
     useEffect(()=>{
         const tl = gsap.timeline();
         switch (progress) {
@@ -92,7 +92,7 @@ export default function Gazebo(props) {
     const getDisabledDays = () => {
         return Disabled_Days.filter(item=>item.Type === bookingDetails.type);
     }
-
+    console.log(errors)
     return (
         <RefContext.Provider value={ContainerRef}>
             <IsDemoContext.Provider value={isDemo}>
@@ -107,8 +107,7 @@ export default function Gazebo(props) {
                                                 <Container fluid className={`px-3 py-2 p-lg-0 text-center mx-auto h-100 mt-0 bg overflow-x-hidden d-flex flex-column ${isDemo ? ' bg' : ' img-container'}`}
                                                            ref={ContainerRef}>
                                                     <DisabledDaysContext.Provider value={getDisabledDays()}>
-                                                        {errors && <AlertMessage variant={'danger'} message={errors} header={'Oh Snap!'} duration={3} shouldShow={true}
-                                                                                 onClose={()=>setErrors(null)} className={'w-fit-content mx-auto px-3 py-1'}/>}
+                                                        {errors && <AlertMessage variant={'danger'} errors={errors} header={'Oh Snap!'} duration={10} shouldShow={true} className={'w-fit-content mx-auto px-3 py-1'}/>}
                                                         <TypeSelectionForm ref={typeRef}>
                                                             {progress === 'Table' && <GazeboSelectionForm Gazebos={Gazebos} ref={tableRef}></GazeboSelectionForm>}
                                                             {progress === 'Details' && <ReservationInfoForm ref={detailsRef}></ReservationInfoForm>}


### PR DESCRIPTION
The new reservation request now has its own request class with the required validation. It validates all the data. It also checks if the selected gazebo was booked on the same day, if the day was disabled or if the gazebo was disabled for that date, while the user was filling the reservation form.

Added a note to indicate which kind of reservations ( Dinner or Bed ) are visible in Today's, Weekly, and Monthly View ( all both Large Screens and mobiles ).

Made some minor UI fixes ( paddings ).

When a reservation is edited in Today's view, it should now fetch the correct type of reservations to re-populate the list. ( was always fetching Dinner reservations., no matter what ).